### PR TITLE
【Fixed】デバッグツールをインストールし、初期設定を行った。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,13 +21,14 @@ gem 'devise'
 gem 'faker'
 group :development do
   gem 'letter_opener_web'
+  gem 'pry-rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
   #gem 'dotenv-rails'
 end
 gem 'rails_admin'
 gem 'cancan'
 group :development, :test do
-  gem 'pry-rails'
-  gem 'better_errors'
   gem 'capistrano', '3.6.0'
   gem 'capistrano-bundler'
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,6 +463,7 @@ PLATFORMS
 DEPENDENCIES
   activeresource
   better_errors
+  binding_of_caller
   byebug
   cancan
   capistrano (= 3.6.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,5 +42,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  BetterErrors::Middleware.allow_ip! "10.0.2.2"
+  BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
 end


### PR DESCRIPTION
#2 

Gemfileに以下を追加
　gem 'pry-rails'
　gem 'better_errors'
　gem 'binding_of_caller'

bundle installを実行

config/environments/development.rbにbetter_errorsの初期設定を追記
　localhost以外からアクセスする場合に許可されるipアドレスを指定する。
　環境変数'TRUSTED_IP'を参照する方式としたため、以下の何れかの対応が必要
　　.envファイルにTRUSTED_IPを記述する
　　rails sコマンドでTRUSTED_IPをオプション指定する
　